### PR TITLE
Add 12 SRG mappings for Arid Expansion 1.0.0

### DIFF
--- a/src/main/java/com/retromod/security/SignatureVerifier.java
+++ b/src/main/java/com/retromod/security/SignatureVerifier.java
@@ -34,7 +34,7 @@ public final class SignatureVerifier {
      * <p>Empty in dev/source builds: status is then {@link Status#UNKNOWN} and the computed
      * hash is logged so a release build can embed it. See {@code docs/authenticity.md}.
      */
-    private static final String EXPECTED_SELF_HASH = "2361326DA6D5491429BFD588D48E207A3B9B95026EEE370F63FF445693F6264B";
+    private static final String EXPECTED_SELF_HASH = "";
 
     /** This class's own jar entry, excluded from the hash (it carries the hash). */
     private static final String SELF_ENTRY = "com/retromod/security/SignatureVerifier.class";

--- a/src/main/resources/retromod/srg-to-mojang.tsv
+++ b/src/main/resources/retromod/srg-to-mojang.tsv
@@ -2139,6 +2139,11 @@ FIELD	f_19279_	combatStartTime
 FIELD	f_19280_	combatEndTime
 FIELD	f_19281_	inCombat
 FIELD	f_19282_	takingDamage
+FIELD	f_19306_	LIGHTNING_BOLT
+FIELD	f_19312_	DROWN
+FIELD	f_19314_	CACTUS
+FIELD	f_19315_	FALL
+FIELD	f_19321_	ANVIL
 FIELD	f_19424_	multiplier
 FIELD	f_19446_	attributeModifiers
 FIELD	f_19447_	category
@@ -31325,6 +31330,7 @@ METHOD	m_7377_	deserialize
 METHOD	m_7378_	readAdditionalSaveData
 METHOD	m_7379_	onClose
 METHOD	m_7380_	addAdditionalSaveData
+METHOD	m_7381_	getDrops
 METHOD	m_7382_	processBlock
 METHOD	m_7383_	getStyle
 METHOD	m_7384_	fixBlock
@@ -35392,6 +35398,7 @@ METHOD	m_41475_	isFireResistant
 METHOD	m_41486_	fireResistant
 METHOD	m_41487_	stacksTo
 METHOD	m_41489_	food
+METHOD	m_41491_	tab
 METHOD	m_41495_	craftRemainder
 METHOD	m_41497_	rarity
 METHOD	m_41499_	defaultDurability
@@ -35823,6 +35830,7 @@ METHOD	m_46472_	dimension
 METHOD	m_46473_	getProfiler
 METHOD	m_46490_	getSunAngle
 METHOD	m_46496_	getBlockRandomPos
+METHOD	m_46511_	explode
 METHOD	m_46575_	loadedAndEntityCanStandOn
 METHOD	m_46578_	loadedAndEntityCanStandOnFace
 METHOD	m_46586_	neighborChanged
@@ -35844,6 +35852,7 @@ METHOD	m_46741_	isInSpawnableBounds
 METHOD	m_46745_	getChunkAt
 METHOD	m_46747_	removeBlockEntity
 METHOD	m_46749_	isLoaded
+METHOD	m_46755_	getBestNeighborSignal
 METHOD	m_46758_	isRainingAt
 METHOD	m_46791_	getDifficulty
 METHOD	m_46796_	levelEvent
@@ -36668,6 +36677,7 @@ METHOD	m_60918_	sound
 METHOD	m_60922_	isValidSpawn
 METHOD	m_60924_	isRedstoneConductor
 METHOD	m_60926_	copy
+METHOD	m_60939_	of
 METHOD	m_60953_	lightLevel
 METHOD	m_60955_	noOcclusion
 METHOD	m_60956_	speedFactor
@@ -47074,11 +47084,13 @@ METHOD	m_206470_	simpleRandomPatchConfiguration
 METHOD	m_206473_	simplePatchConfiguration
 METHOD	m_206476_	simplePatchConfiguration
 METHOD	m_206480_	simplePatchConfiguration
+METHOD	m_206488_	register
 METHOD	m_206493_	filteredByBlockSurvival
 METHOD	m_206495_	onlyWhenEmpty
 METHOD	m_206498_	filtered
 METHOD	m_206502_	inlinePlaced
 METHOD	m_206506_	inlinePlaced
+METHOD	m_206509_	register
 METHOD	m_206517_	isEmpty
 METHOD	m_206606_	create
 METHOD	m_206667_	homogenousList


### PR DESCRIPTION
<!--
Thanks for sending a PR. The checklist below isn't there to be annoying. It's
the stuff I'd otherwise have to ask you about in review. Filling it in up front
saves a round trip.
-->

## What does this PR do?
Adds 12 SRG mapping entries for Arid Expansion 1.0.0 for 1.19.2 found here:
https://modrinth.com/mod/arid-expansion/version/1.0.0
This resolves a few previously missing methods and the report for this mod is now fully named, but the mod itself still needs some work on the remaining issues.
I also removed the hash for this commit (which is probably invalid with the changes to the mapping table and is likely going to be regenerated with the next mainline build).

<!-- One or two sentences. What changed and why. -->

## Type of change

- [ ] New shim (added support for an MC version transition)
- [ ] New polyfill (reimplemented a removed API)
- [x] Mapping update (intermediary → Mojang, or SRG-related)
- [ ] Bug fix
- [ ] Refactor / cleanup
- [ ] Docs only
- [ ] Build / CI
- [ ] Other:

## Testing


<!--
How did you test this? Be specific:
- Which mod(s) did you run it against?
- Which host MC version + loader?
- Did you run `mvn test -Dexec.skip=true`?
- If it's a shim or polyfill, did you confirm an actual mod that needed it now loads?
-->
### Mods
Only Retromod and Arid Expansion. (The mod itself has a dependency on Geckolib which I didn't add to my test instances)

### Host Minecraft and loader
Minecraft 1.20.1 + Forge 47.4.21
Minecraft 26.1.2 + Forge 64.0.11

### Unit test log
[log-2026-07-11_19-45.txt](https://github.com/user-attachments/files/29928807/log-2026-07-11_19-45.txt)

### Verification reports (srg refers to report with a build containing the new entries):
#### Forge 47.4.21 on Minecraft 1.20.1:
[AridExpansion-1.19.2fo-1.0.jar+mc1.20.1+rm1.2.0.txt](https://github.com/user-attachments/files/29928699/AridExpansion-1.19.2fo-1.0.jar%2Bmc1.20.1%2Brm1.2.0.txt)
[AridExpansion-1.19.2fo-1.0.jar+mc.1.20.1+rm1.2.0+srg.txt](https://github.com/user-attachments/files/29928698/AridExpansion-1.19.2fo-1.0.jar%2Bmc.1.20.1%2Brm1.2.0%2Bsrg.txt)
#### Forge 64.0.11 on Minecraft 26.1.2:
[AridExpansion-1.19.2fo-1.0.jar+mc26.1.2+rm1.2.0.txt](https://github.com/user-attachments/files/29928700/AridExpansion-1.19.2fo-1.0.jar%2Bmc26.1.2%2Brm1.2.0.txt)
[AridExpansion-1.19.2fo-1.0.jar+mc26.1.2+rm1.2.0+srg.txt](https://github.com/user-attachments/files/29928701/AridExpansion-1.19.2fo-1.0.jar%2Bmc26.1.2%2Brm1.2.0%2Bsrg.txt)

### Crash logs (since this mod still doesn't transform to a point where it gets to the main menu)
[crash-2026-07-11_19.56.12-fml.txt](https://github.com/user-attachments/files/29929151/crash-2026-07-11_19.56.12-fml.txt)
[crash-2026-07-11_20.01.40-fml.txt](https://github.com/user-attachments/files/29929152/crash-2026-07-11_20.01.40-fml.txt)


## Checklist

- [ ] If I added a shim, I registered it in `META-INF/services/com.retromod.core.VersionShim`
- [ ] If I added a polyfill provider, I registered it in `META-INF/services/com.retromod.polyfill.PolyfillProvider`
- [X] I didn't hardcode an MC version string (used `Retromod.TARGET_MC_VERSION` where needed)
- [X] I didn't delete or weaken existing shims for older MC versions (1.12.2+ shims must stay)
- [X] `mvn test -Dexec.skip=true` passes locally
- [ ] If this changes user-facing behavior, I updated the relevant page under `docs/`

## Related issues

<!-- Closes #123, refs #456, etc. Leave blank if none. -->
